### PR TITLE
Use compact encoding for timestamp when encoding a TrackShipment

### DIFF
--- a/Parity.Substrate.EnterpriseSample/Models/TrackShipmentCall.cs
+++ b/Parity.Substrate.EnterpriseSample/Models/TrackShipmentCall.cs
@@ -1,4 +1,6 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Linq;
+using System.Numerics;
 using Polkadot.BinarySerializer;
 using Polkadot.BinarySerializer.Converters;
 
@@ -13,24 +15,29 @@ namespace Parity.Substrate.EnterpriseSample.Models
         public byte Operation { get; set; }
 
         [Serialize(2)]
-        //[CompactBigIntegerConverter]
-        public long Timestamp { get; set; }
+        [CompactBigIntegerConverter]
+        public BigInteger Timestamp { get; set; }
 
         [Serialize(3)]
-        public ReadPoint Location { get; set; }
+        public byte Location { get; set; }
 
         [Serialize(4)]
-        public ReadingList Readings { get; set; }
+        public byte Readings { get; set; }
 
         public TrackShipmentCall(Identifier shipmentId,
-            byte operation, long timestamp,
-            ReadPoint location, ReadingList readings)
+            int operation, long timestamp,
+            ReadPoint location,
+            ReadingList readings)
         {
             ShipmentId = shipmentId;
-            Operation = operation;
-            Timestamp = timestamp;
-            Location = location;
-            Readings = readings;
+            // SCALE-encoded enum (int bytes are LE on ARM hence First)
+            Operation = BitConverter.GetBytes(operation).First();
+            Timestamp = new BigInteger(timestamp);
+            //TODO: ignore location & readings args for now,
+            // there is an issue with SCALE-encoding OneOf<Empty,T>,
+            // so we pass empty option (1 zero-byte) for now.
+            Location = new byte();
+            Readings = new byte();
         }
     }
 }

--- a/Parity.Substrate.EnterpriseSample/ViewModels/BaseViewModel.cs
+++ b/Parity.Substrate.EnterpriseSample/ViewModels/BaseViewModel.cs
@@ -1,5 +1,8 @@
-﻿using Parity.Substrate.EnterpriseSample.Services;
+﻿using System.Linq;
+using Parity.Substrate.EnterpriseSample.Services;
 using Polkadot.Api;
+using Polkadot.DataStructs;
+using Polkadot.Utils;
 using Prism.Mvvm;
 using Prism.Navigation;
 
@@ -62,6 +65,15 @@ namespace Parity.Substrate.EnterpriseSample.ViewModels
         public virtual void Destroy()
         {
 
+        }
+
+        protected T GetValueFromStorageMap<T>(string module, string storageMap, object key)
+        {
+            var param = PolkadotApi.Serializer.Serialize(key);
+            var paramKey = Hash.GetStorageKey(Hasher.BLAKE2, param, param.Length, PolkadotApi.Serializer);
+
+            var response = PolkadotApi.GetStorage(paramKey.Concat(param).ToArray(), module, storageMap);
+            return PolkadotApi.Serializer.Deserialize<T>(response.HexToByteArray());
         }
     }
 }


### PR DESCRIPTION
 extrinsic (and use the binary serializer to do so instead of doing by hand).
Also, simplify some code.

Fixes #12 